### PR TITLE
merge :: 공통적으로 쓰일 backButton config하는 extension

### DIFF
--- a/Projects/UsertInterfaces/DesignSystem/Sources/Extensions/View+configBackButton.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/Extensions/View+configBackButton.swift
@@ -1,11 +1,19 @@
 import SwiftUI
 
-public extension View {
-    func configBackButton(
-        willDismiss: @escaping () -> Void = {},
+struct DmsBackButtonModifier: ViewModifier {
+    let willDismiss: () -> Void
+    let dismiss: DismissAction
+
+    public init(
+        willDismiss: @escaping () -> Void,
         dismiss: DismissAction
-    ) -> some View {
-        self
+    ) {
+        self.willDismiss = willDismiss
+        self.dismiss = dismiss
+    }
+
+    func body(content: Content) -> some View {
+        content
             .toolbar {
                 ToolbarItemGroup(placement: .navigationBarLeading) {
                     Button {
@@ -20,6 +28,14 @@ public extension View {
                 }
             }
             .navigationBarBackButtonHidden(true)
+    }
+}
+public extension View {
+    func configBackButton(
+        willDismiss: @escaping () -> Void = {},
+        dismiss: DismissAction
+    ) -> some View {
+        modifier(DmsBackButtonModifier(willDismiss: willDismiss, dismiss: dismiss))
     }
 }
 

--- a/Projects/UsertInterfaces/DesignSystem/Sources/Extensions/View+configBackButton.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/Extensions/View+configBackButton.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+public extension View {
+    func configBackButton(
+        willDismiss: @escaping () -> Void = {},
+        dismiss: DismissAction
+    ) -> some View {
+        self
+            .toolbar {
+                ToolbarItemGroup(placement: .navigationBarLeading) {
+                    Button {
+                        willDismiss()
+                        dismiss()
+                    } label: {
+                        Image(systemName: "chevron.left")
+                            .resizable()
+                            .frame(width: 9, height: 16)
+                            .foregroundColor(.GrayScale.gray9)
+                    }
+                }
+            }
+            .navigationBarBackButtonHidden(true)
+    }
+}
+
+// SwipeGesture로 뒤로갈 수 있게 하는 extension
+extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}

--- a/Projects/UsertInterfaces/DesignSystem/Sources/Extensions/View+configBackButton.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/Extensions/View+configBackButton.swift
@@ -31,7 +31,7 @@ struct DmsBackButtonModifier: ViewModifier {
     }
 }
 public extension View {
-    func configBackButton(
+    func dmsBackButton(
         willDismiss: @escaping () -> Void = {},
         dismiss: DismissAction
     ) -> some View {


### PR DESCRIPTION
## 개요
 공통적으로 쓰일 backButton config하는 extension

## 작업사항
- configBackButton extension 추가
- navigationBarBackButtonHidden을 true로 하기에 swipeGesture로는 뒤로가기를 실행할 수 없기에 이를 해결하는 UINavigationController extension 작업

## 사용방법
```swift
@Environment(\.dismiss) var dismiss
VStack {

}
.dmsBackButton(dismiss: dismiss)


