### PR TITLE
merge :: Toast 자동 닫히기 로직 변경

### DIFF
--- a/Projects/UsertInterfaces/DesignSystem/Sources/Toast/DmsToast.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/Toast/DmsToast.swift
@@ -21,6 +21,15 @@ struct DmsToast: ViewModifier {
 
             dmsToastView()
         }
+        .onChange(of: isShowing) { newValue in
+            if isShowing {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    withAnimation {
+                        isShowing = false
+                    }
+                }
+            }
+        }
     }
 
     @ViewBuilder
@@ -57,13 +66,6 @@ struct DmsToast: ViewModifier {
                 .onTapGesture {
                     withAnimation {
                         isShowing = false
-                    }
-                }
-                .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                        withAnimation {
-                            isShowing = false
-                        }
                     }
                 }
             }


### PR DESCRIPTION
## 개요
Toast 자동 닫히기 로직 변경

## 작업사항
- 바인딩된 값이 바뀌는 시점을 기준으로 2초를 카운트 다운

## 변경로직
- 2초 세는 시점 변경

### 변경전
- onAppear를 기준으로 2초를 셈

### 변경후
- isShowing의 onChange를 기준으로 2초를 셈

