### PR TITLE
merge ::  Design System PassCodeview

### DIFF
--- a/Projects/Features/SignupFeature/Sources/SchoolCodeView.swift
+++ b/Projects/Features/SignupFeature/Sources/SchoolCodeView.swift
@@ -28,7 +28,7 @@ struct SchoolCodeView: View {
                 .frame(height: 60)
 
             VStack {
-                PasscodeView(text: $viewModel.schoolCode)
+                DMSPassCodeView(codeCount: 8, text: $viewModel.schoolCode)
                     .padding(.horizontal, 64)
                     .onChange(of: viewModel.schoolCode) { _ in
                         viewModel.checkIsEmptyAuthCode()

--- a/Projects/UsertInterfaces/DesignSystem/Sources/BottomSheet/DMSBottomSheet.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/BottomSheet/DMSBottomSheet.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct DmsBottomSheet<T: View>: ViewModifier {
+struct DMSBottomSheet<T: View>: ViewModifier {
     @Binding var isShowing: Bool
     @State var dragHeight: CGFloat = 0
     var content: () -> T
@@ -89,6 +89,6 @@ public extension View {
         isShowing: Binding<Bool>,
         content: @escaping () -> Content
     ) -> some View {
-        modifier(DmsBottomSheet(isShowing: isShowing, content: content))
+        modifier(DMSBottomSheet(isShowing: isShowing, content: content))
     }
 }

--- a/Projects/UsertInterfaces/DesignSystem/Sources/PassCode/DMSPassCodeView.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/PassCode/DMSPassCodeView.swift
@@ -10,7 +10,7 @@ public struct DMSPassCodeView: View {
     public init(
         codeCount: Int,
         text: Binding<String>
-        ) {
+    ) {
         self.codeCount = codeCount
         _text = text
     }

--- a/Projects/UsertInterfaces/DesignSystem/Sources/PassCode/DMSPassCodeView.swift
+++ b/Projects/UsertInterfaces/DesignSystem/Sources/PassCode/DMSPassCodeView.swift
@@ -1,12 +1,21 @@
 import SwiftUI
-
 import Combine
 
-struct PasscodeView: View {
+public struct DMSPassCodeView: View {
+
+    @State var codeCount: Int
     @Binding var text: String
     @FocusState var focused: Bool
 
-    var body: some View {
+    public init(
+        codeCount: Int,
+        text: Binding<String>
+        ) {
+        self.codeCount = codeCount
+        _text = text
+    }
+
+    public var body: some View {
         VStack {
             ZStack {
                 TextField("", text: $text)
@@ -15,13 +24,13 @@ struct PasscodeView: View {
                     .accentColor(.clear)
                     .foregroundColor(.clear)
                     .onReceive(Just(text), perform: { _ in
-                        if 8 < text.count {
-                            text = String(text.prefix(8))
+                        if codeCount < text.count {
+                            text = String(text.prefix(codeCount))
                         }
                     })
 
                 HStack(spacing: 20) {
-                    ForEach(1...8, id: \.self) { num in
+                    ForEach(1...codeCount, id: \.self) { num in
                         Circle()
                             .frame(width: 20, height: 20)
                             .foregroundColor(text.count >= num ? Color.GrayScale.gray6 : Color.GrayScale.gray4)


### PR DESCRIPTION
## 개요
SignUpFeature에 있는 PassCodeView를 DesignSystem으로 들고 온 후 이름 변경과 인증번호 숫자 커스텀이 가능하게 변경하였습니다.

## 작업사항
- SignUpFeature에 있는 PassCodeView 삭제
- DMSPassCodeView 추가 (숫자 커스텀 가능)
- DmsBottomSheet를 DMSBottomSheet로 이름 변경
