### PR TITLE
refactor :: 잔류 신청 버튼 bottom padding 줄이기

### DIFF
--- a/Projects/Features/RemainApplyFeature/Sources/RemainApplyView.swift
+++ b/Projects/Features/RemainApplyFeature/Sources/RemainApplyView.swift
@@ -37,6 +37,7 @@ struct RemainApplyView: View {
         }
         .navigationTitle("잔류 신청")
         .navigationBarTitleDisplayMode(.inline)
+        .ignoresSafeArea(edges: .bottom)
         .dmsBackground()
         .dmsBackButton(dismiss: dismiss)
         .dmsToast(


### PR DESCRIPTION
## 개요
- 잔류 신청 버튼 bottom padding 줄이기

## 작업사항
- 잔류 신청 페이지의 버튼 bottom padding 값을 줄였습니다.

## 기타
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-02 at 22 15 08](https://user-images.githubusercontent.com/101160430/222438905-998c888b-4c63-41fc-a9ca-bd3e736aed0d.png)

