### PR TITLE
feat :: 공지 위젯 fixedSize 설정 변경

### DIFF
--- a/Projects/App/AppExtension/Sources/Notice/DMSNoticeEntryView.swift
+++ b/Projects/App/AppExtension/Sources/Notice/DMSNoticeEntryView.swift
@@ -44,7 +44,7 @@ private struct SmallDMSNoticeWidgetView: View {
 
             Text(entry.notice.title)
                 .dmsFont(.etc(.caption), color: colorScheme == .light ? .GrayScale.gray6 : .GrayScale.gray7)
-                .fixedSize()
+                .fixedSize(horizontal: false, vertical: true)
 
             Text("more...")
                 .dmsFont(.etc(.overline), color: .PrimaryVariant.darken1)


### PR DESCRIPTION
## 개요
- 정사각형 형태의 공지 위젯은 양 옆에 padding이 필요해보여요..

## 작업사항
- SmallDMSNoticeWidgetView의 공지 제목 text fixedSize 설정 변경

## UI
- 변경 전
![image](https://user-images.githubusercontent.com/101160430/224487030-49163bc4-2044-420b-8fa4-fb2f646ba6c2.png)

- 변경 후
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-11 at 22 20 31](https://user-images.githubusercontent.com/101160430/224487001-000e3bcd-7b4b-44bf-aa9b-23b39e420a6f.png)

