### PR TITLE
자습실 목록 보기 UI 퍼블리싱 및 API 수정

### DIFF
--- a/Projects/Features/StudyRoomFeature/Sources/Component/StudyRoomListCellView.swift
+++ b/Projects/Features/StudyRoomFeature/Sources/Component/StudyRoomListCellView.swift
@@ -25,8 +25,22 @@ struct StudyRoomListCellView: View {
                         .dmsFont(.body(.body3), color: .GrayScale.gray5)
                 }
 
-                Text("\(gradeToString(studyRoomEntity.availableGrade)) \(studyRoomEntity.availableSex.displayString())")
-                    .dmsFont(.body(.body3), color: .System.primary)
+                HStack {
+                    Text(gradeToString(studyRoomEntity.availableGrade) + " " +
+                         studyRoomEntity.availableSex.displayString())
+                        .dmsFont(.body(.body3), color: .System.primary)
+
+                    Spacer()
+
+                    if studyRoomEntity.isMine {
+                        Text("신청함")
+                            .dmsFont(.etc(.overline), color: .System.surface)
+                            .padding(.vertical, 3)
+                            .padding(.horizontal, 11)
+                            .background(Color.PrimaryVariant.primary)
+                            .cornerRadius(11)
+                    }
+                }
             }
             .padding(.vertical, 16)
             .padding(.horizontal, 16)

--- a/Projects/Features/StudyRoomFeature/Sources/StudyRoomDetail/StudyRoomDetailComponent.swift
+++ b/Projects/Features/StudyRoomFeature/Sources/StudyRoomDetail/StudyRoomDetailComponent.swift
@@ -12,10 +12,11 @@ public protocol StudyRoomDetailDependency: Dependency {
 }
 
 public final class StudyRoomDetailComponent: Component<StudyRoomDetailDependency> {
-    public func makeView(studyRoomEntity: StudyRoomEntity) -> some View {
+    public func makeView(studyRoomEntity: StudyRoomEntity, timeSlot: String) -> some View {
         StudyRoomDetailView(
             viewModel: .init(
                 studyRoomEntity: studyRoomEntity,
+                timeSlotParam: timeSlot,
                 fetchStudyAvailableTimeUseCase: dependency.fetchStudyAvailableTimeUseCase,
                 fetchSeatTypesUseCase: dependency.fetchSeatTypesUseCase,
                 fetchDetailStudyRoomUseCase: dependency.fetchDetailStudyRoomUseCase,

--- a/Projects/Features/StudyRoomFeature/Sources/StudyRoomDetail/StudyRoomDetailViewModel.swift
+++ b/Projects/Features/StudyRoomFeature/Sources/StudyRoomDetail/StudyRoomDetailViewModel.swift
@@ -13,6 +13,7 @@ final class StudyRoomDetailViewModel: BaseViewModel {
     @Published var isShowingToast = false
     @Published var toastMessage = ""
     @Published var selectedSeat: SeatEntity?
+    @Published var timeSlotParam: String = ""
 
     let studyRoomEntity: StudyRoomEntity
 
@@ -24,6 +25,7 @@ final class StudyRoomDetailViewModel: BaseViewModel {
 
     public init(
         studyRoomEntity: StudyRoomEntity,
+        timeSlotParam: String,
         fetchStudyAvailableTimeUseCase: any FetchStudyAvailableTimeUseCase,
         fetchSeatTypesUseCase: any FetchSeatTypesUseCase,
         fetchDetailStudyRoomUseCase: any FetchDetailStudyRoomUseCase,
@@ -31,6 +33,7 @@ final class StudyRoomDetailViewModel: BaseViewModel {
         cancelStudyRoomSeatUseCase: any CancelStudyRoomSeatUseCase
     ) {
         self.studyRoomEntity = studyRoomEntity
+        self.timeSlotParam = timeSlotParam
         self.fetchStudyAvailableTimeUseCase = fetchStudyAvailableTimeUseCase
         self.fetchSeatTypesUseCase = fetchSeatTypesUseCase
         self.fetchDetailStudyRoomUseCase = fetchDetailStudyRoomUseCase
@@ -66,7 +69,8 @@ final class StudyRoomDetailViewModel: BaseViewModel {
         var newSeatArray: [SeatEntity] = []
         addCancellable(
             fetchDetailStudyRoomUseCase.execute(
-                roomID: self.studyRoomEntity.id
+                roomID: self.studyRoomEntity.id,
+                timeSlot: self.timeSlotParam
             )
         ) { [weak self] detailStudyRoom in
             newSeatArray = self?.addEmptySeat(
@@ -96,7 +100,7 @@ final class StudyRoomDetailViewModel: BaseViewModel {
     func applyStudyRoomSeat() {
         guard let selectedSeat else { return }
         addCancellable(
-            applyStudyRoomSeatUseCase.execute(seatID: selectedSeat.id)
+            applyStudyRoomSeatUseCase.execute(seatID: selectedSeat.id, timeSlot: timeSlotParam)
         ) { [weak self] _ in
             self?.fetchDetailStudyRoom()
             self?.isShowingToast = true
@@ -109,7 +113,7 @@ final class StudyRoomDetailViewModel: BaseViewModel {
 
     func cancelStudyRoomSeat() {
         addCancellable(
-            cancelStudyRoomSeatUseCase.execute()
+            cancelStudyRoomSeatUseCase.execute(timeSlot: timeSlotParam)
         ) { [weak self] _ in
             self?.fetchDetailStudyRoom()
             self?.isShowingToast = true

--- a/Projects/Features/StudyRoomFeature/Sources/StudyroomApplication/StudyRoomListView.swift
+++ b/Projects/Features/StudyRoomFeature/Sources/StudyroomApplication/StudyRoomListView.swift
@@ -38,7 +38,8 @@ struct StudyRoomListView: View {
                                 .padding(.top, 4)
                                 .padding(.trailing, 11)
 
-                            Text("10시 ~ 11시")
+                            Text((viewModel.selectedTimeEntity?.startTime ?? "")
+                                 + " ~ " + (viewModel.selectedTimeEntity?.endTime ?? ""))
                                 .dmsFont(.etc(.button), color: .PrimaryVariant.primary)
 
                             Spacer()
@@ -85,7 +86,10 @@ struct StudyRoomListView: View {
             viewModel.onAppear()
         }
         .navigate(
-            to: studyRoomDetailComponent.makeView(studyRoomEntity: viewModel.studyRoomDetail),
+            to: studyRoomDetailComponent.makeView(
+                studyRoomEntity: viewModel.studyRoomDetail,
+                timeSlot: viewModel.timeSlotParam ?? ""
+            ),
             when: $viewModel.isNavigateDetail
         )
     }

--- a/Projects/Features/StudyRoomFeature/Sources/StudyroomApplication/StudyRoomListViewModel.swift
+++ b/Projects/Features/StudyRoomFeature/Sources/StudyroomApplication/StudyRoomListViewModel.swift
@@ -12,10 +12,11 @@ final class StudyRoomListViewModel: BaseViewModel {
     @Published var toastMessage = ""
 
     @Published var isNavigateDetail: Bool = false
-    @Published var isStudyTimeBottomSheet: Bool = false
+    @Published var isStudyTimeBottomSheet: Bool = true
 
     @Published var studyroomTimeList = StudyroomTimeListEntity(timeSlots: [])
     @Published var selectedTimeEntity: TimeSlotsEntity?
+    @Published var timeSlotParam: String?
     @Published var studyAvailableTime: StudyAvailableTimeEntity?
     @Published var studyRoomDetail: StudyRoomEntity = .init(
         id: "",
@@ -55,7 +56,9 @@ final class StudyRoomListViewModel: BaseViewModel {
 
     func fetchStudyRoomList() {
         addCancellable(
-            fetchStudyRoomListUseCase.execute()
+            fetchStudyRoomListUseCase.execute(
+                timeSlot: timeSlotParam
+            )
         ) { [weak self]  studyRoomList in
             self?.studyRoomList = studyRoomList
         }
@@ -78,12 +81,11 @@ final class StudyRoomListViewModel: BaseViewModel {
     }
 
     func onAppear() {
-        fetchStudyRoomList()
         fetchStudyAvailableTime()
     }
 
     func refresh() {
-        fetchStudyRoomList()
         fetchStudyAvailableTime()
+        fetchStudyRoomList()
     }
 }

--- a/Projects/Features/StudyRoomFeature/Sources/StudyroomApplication/StudyroomTimeList/StudyroomTimeListView.swift
+++ b/Projects/Features/StudyRoomFeature/Sources/StudyroomApplication/StudyroomTimeList/StudyroomTimeListView.swift
@@ -21,6 +21,7 @@ struct StudyroomTimeListView: View {
                             timeSlots: timeSlots,
                             buttonAction: {
                                 viewModel.selectedTimeEntity = timeSlots
+                                viewModel.timeSlotParam = timeSlots.id
                             }
                         )
                     }
@@ -31,6 +32,7 @@ struct StudyroomTimeListView: View {
 
             DMSWideButton(text: "확인", style: .contained, color: .PrimaryVariant.primary) {
                 viewModel.isStudyTimeBottomSheet = false
+                viewModel.refresh()
             }
             .padding(.horizontal, 24)
             .padding(.bottom)

--- a/Projects/Services/APIKit/Sources/FilesAPI.swift
+++ b/Projects/Services/APIKit/Sources/FilesAPI.swift
@@ -4,7 +4,6 @@ import Moya
 
 public enum FilesAPI {
     case uploadFile(data: Data)
-    case fetchPresignedURL(data: Data)
 }
 
 extension FilesAPI: DmsAPI {

--- a/Projects/Services/APIKit/Sources/FilesAPI.swift
+++ b/Projects/Services/APIKit/Sources/FilesAPI.swift
@@ -4,6 +4,7 @@ import Moya
 
 public enum FilesAPI {
     case uploadFile(data: Data)
+    case fetchPresignedURL(data: Data)
 }
 
 extension FilesAPI: DmsAPI {

--- a/Projects/Services/APIKit/Sources/StudyRoomsAPI.swift
+++ b/Projects/Services/APIKit/Sources/StudyRoomsAPI.swift
@@ -1,15 +1,16 @@
 import DataMappingModule
+import Foundation
 import ErrorModule
 import Moya
 
 public enum StudyRoomsAPI {
     case fetchStudyAvailableTime
     case fetchSeatTypes
-    case fetchStudyRoomList
-    case fetchDetailStudyRoom(roomID: String)
+    case fetchStudyRoomList(timeSlot: String?)
+    case fetchDetailStudyRoom(roomID: String, timeSlot: String)
     case fetchMyStudyRoomApplicationItems
-    case applyStudyRoomSeat(seatID: String)
-    case cancelStudyRoomSeat
+    case applyStudyRoomSeat(seatID: String, timeSlot: String)
+    case cancelStudyRoomSeat(timeSlot: String)
     case fetchStudyroomTimeList
 }
 
@@ -29,10 +30,10 @@ extension StudyRoomsAPI: DmsAPI {
         case .fetchStudyRoomList:
             return "/list/students"
 
-        case let .fetchDetailStudyRoom(id):
+        case let .fetchDetailStudyRoom(id, _):
             return "/\(id)/students"
 
-        case let .applyStudyRoomSeat(id):
+        case let .applyStudyRoomSeat(id, _):
             return "/seats/\(id)"
 
         case .cancelStudyRoomSeat:
@@ -62,7 +63,41 @@ extension StudyRoomsAPI: DmsAPI {
     }
 
     public var task: Moya.Task {
-        .requestPlain
+        switch self {
+        case let .fetchStudyRoomList(timeSlot):
+            return .requestParameters(
+                parameters: [
+                    "time_slot": timeSlot ?? ""
+                ],
+                encoding: URLEncoding.queryString
+            )
+
+        case let .fetchDetailStudyRoom(_, timeSlot):
+            return .requestParameters(
+                parameters: [
+                    "time_slot": timeSlot
+                ],
+                encoding: URLEncoding.queryString
+            )
+
+        case let .applyStudyRoomSeat(_, timeSlot):
+            return .requestParameters(
+                parameters: [
+                    "time_slot": timeSlot
+                ],
+                encoding: URLEncoding.queryString
+            )
+
+        case let .cancelStudyRoomSeat(timeSlot):
+            return .requestParameters(
+                parameters: [
+                    "time_slot": timeSlot
+                ],
+                encoding: URLEncoding.queryString
+            )
+        default:
+            return .requestPlain
+        }
     }
 
     public var jwtTokenType: JwtTokenType {

--- a/Projects/Services/DataModule/Sources/StudyRooms/Repositories/Impl/StudyRoomsRepositoryImpl.swift
+++ b/Projects/Services/DataModule/Sources/StudyRooms/Repositories/Impl/StudyRoomsRepositoryImpl.swift
@@ -19,20 +19,23 @@ public struct StudyRoomsRepositoryImpl: StudyRoomsRepository {
         remoteStudyRoomsDataSource.fetchSeatTypes()
     }
 
-    public func fetchStudyRoomList() -> AnyPublisher<[StudyRoomEntity], DmsError> {
-        remoteStudyRoomsDataSource.fetchStudyRoomList()
+    public func fetchStudyRoomList(timeSlot: String?) -> AnyPublisher<[StudyRoomEntity], DmsError> {
+        remoteStudyRoomsDataSource.fetchStudyRoomList(timeSlot: timeSlot)
     }
 
-    public func fetchDetailStudyRoom(roomID: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError> {
-        remoteStudyRoomsDataSource.fetchDetailStudyRoom(roomID: roomID)
+    public func fetchDetailStudyRoom(
+        roomID: String,
+        timeSlot: String
+    ) -> AnyPublisher<DetailStudyRoomEntity, DmsError> {
+        remoteStudyRoomsDataSource.fetchDetailStudyRoom(roomID: roomID, timeSlot: timeSlot)
     }
 
-    public func applyStudyRoomSeat(seatID: String) -> AnyPublisher<Void, DmsError> {
-        remoteStudyRoomsDataSource.applyStudyRoomSeat(seatID: seatID)
+    public func applyStudyRoomSeat(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError> {
+        remoteStudyRoomsDataSource.applyStudyRoomSeat(seatID: seatID, timeSlot: timeSlot)
     }
 
-    public func cancelStudyRoomSeat() -> AnyPublisher<Void, DmsError> {
-        remoteStudyRoomsDataSource.cancelStudyRoomSeat()
+    public func cancelStudyRoomSeat(timeSlot: String) -> AnyPublisher<Void, DmsError> {
+        remoteStudyRoomsDataSource.cancelStudyRoomSeat(timeSlot: timeSlot)
     }
 
     public func fetchMyStudyRoomApplicationItems() -> AnyPublisher<MyStudyRoomAppItemsEntity, DmsError> {

--- a/Projects/Services/DataModule/Sources/StudyRooms/UseCases/Impl/ApplyStudyRoomSeatUseCaseImpl.swift
+++ b/Projects/Services/DataModule/Sources/StudyRooms/UseCases/Impl/ApplyStudyRoomSeatUseCaseImpl.swift
@@ -10,7 +10,7 @@ public struct ApplyStudyRoomSeatUseCaseImpl: ApplyStudyRoomSeatUseCase {
         self.studyRoomsRepository = studyRoomsRepository
     }
 
-    public func execute(seatID: String) -> AnyPublisher<Void, DmsError> {
-        studyRoomsRepository.applyStudyRoomSeat(seatID: seatID)
+    public func execute(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError> {
+        studyRoomsRepository.applyStudyRoomSeat(seatID: seatID, timeSlot: timeSlot)
     }
 }

--- a/Projects/Services/DataModule/Sources/StudyRooms/UseCases/Impl/CancelStudyRoomSeatUseCaseImpl.swift
+++ b/Projects/Services/DataModule/Sources/StudyRooms/UseCases/Impl/CancelStudyRoomSeatUseCaseImpl.swift
@@ -10,7 +10,7 @@ public struct CancelStudyRoomSeatUseCaseImpl: CancelStudyRoomSeatUseCase {
         self.studyRoomsRepository = studyRoomsRepository
     }
 
-    public func execute() -> AnyPublisher<Void, DmsError> {
-        studyRoomsRepository.cancelStudyRoomSeat()
+    public func execute(timeSlot: String) -> AnyPublisher<Void, DmsError> {
+        studyRoomsRepository.cancelStudyRoomSeat(timeSlot: timeSlot)
     }
 }

--- a/Projects/Services/DataModule/Sources/StudyRooms/UseCases/Impl/FetchDetailStudyRoomUseCaseImpl.swift
+++ b/Projects/Services/DataModule/Sources/StudyRooms/UseCases/Impl/FetchDetailStudyRoomUseCaseImpl.swift
@@ -10,7 +10,7 @@ public struct FetchDetailStudyRoomUseCaseImpl: FetchDetailStudyRoomUseCase {
         self.studyRoomsRepository = studyRoomsRepository
     }
 
-    public func execute(roomID: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError> {
-        studyRoomsRepository.fetchDetailStudyRoom(roomID: roomID)
+    public func execute(roomID: String, timeSlot: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError> {
+        studyRoomsRepository.fetchDetailStudyRoom(roomID: roomID, timeSlot: timeSlot)
     }
 }

--- a/Projects/Services/DataModule/Sources/StudyRooms/UseCases/Impl/FetchStudyRoomListUseCaseImpl.swift
+++ b/Projects/Services/DataModule/Sources/StudyRooms/UseCases/Impl/FetchStudyRoomListUseCaseImpl.swift
@@ -10,7 +10,7 @@ public struct FetchStudyRoomListUseCaseImpl: FetchStudyRoomListUseCase {
         self.studyRoomsRepository = studyRoomsRepository
     }
 
-    public func execute() -> AnyPublisher<[StudyRoomEntity], DmsError> {
-        studyRoomsRepository.fetchStudyRoomList()
+    public func execute(timeSlot: String?) -> AnyPublisher<[StudyRoomEntity], DmsError> {
+        studyRoomsRepository.fetchStudyRoomList(timeSlot: timeSlot)
     }
 }

--- a/Projects/Services/DomainModule/Sources/StudyRooms/Repository/StudyRoomsRepository.swift
+++ b/Projects/Services/DomainModule/Sources/StudyRooms/Repository/StudyRoomsRepository.swift
@@ -5,10 +5,10 @@ import ErrorModule
 public protocol StudyRoomsRepository {
     func fetchStudyAvailableTime() -> AnyPublisher<StudyAvailableTimeEntity, DmsError>
     func fetchSeatTypes() -> AnyPublisher<[SeatTypeEntity], DmsError>
-    func fetchStudyRoomList() -> AnyPublisher<[StudyRoomEntity], DmsError>
-    func fetchDetailStudyRoom(roomID: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError>
-    func applyStudyRoomSeat(seatID: String) -> AnyPublisher<Void, DmsError>
-    func cancelStudyRoomSeat() -> AnyPublisher<Void, DmsError>
+    func fetchStudyRoomList(timeSlot: String?) -> AnyPublisher<[StudyRoomEntity], DmsError>
+    func fetchDetailStudyRoom(roomID: String, timeSlot: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError>
+    func applyStudyRoomSeat(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError>
+    func cancelStudyRoomSeat(timeSlot: String) -> AnyPublisher<Void, DmsError>
     func fetchMyStudyRoomApplicationItems() -> AnyPublisher<MyStudyRoomAppItemsEntity, DmsError>
     func fetchStudyroomTimeList() -> AnyPublisher<StudyroomTimeListEntity, DmsError>
 }

--- a/Projects/Services/DomainModule/Sources/StudyRooms/UseCases/ApplyStudyRoomSeatUseCase.swift
+++ b/Projects/Services/DomainModule/Sources/StudyRooms/UseCases/ApplyStudyRoomSeatUseCase.swift
@@ -3,5 +3,5 @@ import DataMappingModule
 import ErrorModule
 
 public protocol ApplyStudyRoomSeatUseCase {
-    func execute(seatID: String) -> AnyPublisher<Void, DmsError>
+    func execute(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError>
 }

--- a/Projects/Services/DomainModule/Sources/StudyRooms/UseCases/CancelStudyRoomSeatUseCase.swift
+++ b/Projects/Services/DomainModule/Sources/StudyRooms/UseCases/CancelStudyRoomSeatUseCase.swift
@@ -3,5 +3,5 @@ import DataMappingModule
 import ErrorModule
 
 public protocol CancelStudyRoomSeatUseCase {
-    func execute() -> AnyPublisher<Void, DmsError>
+    func execute(timeSlot: String) -> AnyPublisher<Void, DmsError>
 }

--- a/Projects/Services/DomainModule/Sources/StudyRooms/UseCases/FetchDetailStudyRoomUseCase.swift
+++ b/Projects/Services/DomainModule/Sources/StudyRooms/UseCases/FetchDetailStudyRoomUseCase.swift
@@ -3,5 +3,5 @@ import DataMappingModule
 import ErrorModule
 
 public protocol FetchDetailStudyRoomUseCase {
-    func execute(roomID: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError>
+    func execute(roomID: String, timeSlot: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError>
 }

--- a/Projects/Services/DomainModule/Sources/StudyRooms/UseCases/FetchStudyRoomListUseCase.swift
+++ b/Projects/Services/DomainModule/Sources/StudyRooms/UseCases/FetchStudyRoomListUseCase.swift
@@ -3,5 +3,5 @@ import DataMappingModule
 import ErrorModule
 
 public protocol FetchStudyRoomListUseCase {
-    func execute() -> AnyPublisher<[StudyRoomEntity], DmsError>
+    func execute(timeSlot: String?) -> AnyPublisher<[StudyRoomEntity], DmsError>
 }

--- a/Projects/Services/NetworkModule/Sources/StudyRooms/Remote/Impl/RemoteStudyRoomsDataSourceImpl.swift
+++ b/Projects/Services/NetworkModule/Sources/StudyRooms/Remote/Impl/RemoteStudyRoomsDataSourceImpl.swift
@@ -29,23 +29,26 @@ public final class RemoteStudyRoomsDataSourceImpl: BaseRemoteDataSource<StudyRoo
             .eraseToAnyPublisher()
     }
 
-    public func fetchStudyRoomList() -> AnyPublisher<[StudyRoomEntity], DmsError> {
-        request(.fetchStudyRoomList, dto: FetchStudyRoomListResponDTO.self)
+    public func fetchStudyRoomList(timeSlot: String?) -> AnyPublisher<[StudyRoomEntity], DmsError> {
+        request(.fetchStudyRoomList(timeSlot: timeSlot), dto: FetchStudyRoomListResponDTO.self)
             .map { $0.toDomain() }
             .eraseToAnyPublisher()
     }
 
-    public func fetchDetailStudyRoom(roomID: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError> {
-        request(.fetchDetailStudyRoom(roomID: roomID), dto: FetchDetailStudyRoomResponseDTO.self)
+    public func fetchDetailStudyRoom(
+        roomID: String,
+        timeSlot: String
+    ) -> AnyPublisher<DetailStudyRoomEntity, DmsError> {
+        request(.fetchDetailStudyRoom(roomID: roomID, timeSlot: timeSlot), dto: FetchDetailStudyRoomResponseDTO.self)
             .map { $0.toDomain() }
             .eraseToAnyPublisher()
     }
 
-    public func applyStudyRoomSeat(seatID: String) -> AnyPublisher<Void, DmsError> {
-        request(.applyStudyRoomSeat(seatID: seatID))
+    public func applyStudyRoomSeat(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError> {
+        request(.applyStudyRoomSeat(seatID: seatID, timeSlot: timeSlot))
     }
 
-    public func cancelStudyRoomSeat() -> AnyPublisher<Void, DmsError> {
-        request(.cancelStudyRoomSeat)
+    public func cancelStudyRoomSeat(timeSlot: String) -> AnyPublisher<Void, DmsError> {
+        request(.cancelStudyRoomSeat(timeSlot: timeSlot))
     }
 }

--- a/Projects/Services/NetworkModule/Sources/StudyRooms/Remote/RemoteStudyRoomsDataSource.swift
+++ b/Projects/Services/NetworkModule/Sources/StudyRooms/Remote/RemoteStudyRoomsDataSource.swift
@@ -8,10 +8,10 @@ import Foundation
 public protocol RemoteStudyRoomsDataSource {
     func fetchStudyAvailableTime() -> AnyPublisher<StudyAvailableTimeEntity, DmsError>
     func fetchSeatTypes() -> AnyPublisher<[SeatTypeEntity], DmsError>
-    func fetchStudyRoomList() -> AnyPublisher<[StudyRoomEntity], DmsError>
-    func fetchDetailStudyRoom(roomID: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError>
-    func applyStudyRoomSeat(seatID: String) -> AnyPublisher<Void, DmsError>
-    func cancelStudyRoomSeat() -> AnyPublisher<Void, DmsError>
+    func fetchStudyRoomList(timeSlot: String?) -> AnyPublisher<[StudyRoomEntity], DmsError>
+    func fetchDetailStudyRoom(roomID: String, timeSlot: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError>
+    func applyStudyRoomSeat(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError>
+    func cancelStudyRoomSeat(timeSlot: String) -> AnyPublisher<Void, DmsError>
     func fetchMyRemainApplicationItems() -> AnyPublisher<MyStudyRoomAppItemsEntity, DmsError>
     func fetchStudyroomTimeList() -> AnyPublisher<StudyroomTimeListEntity, DmsError>
 }


### PR DESCRIPTION
## 개요
- 자습실 목록 보기 신청함 태그 뷰가 아무도 모르는 새에 추가 되었습니다.... 그래서 퍼블리싱을 해야합니다.....
- 자습실 목록 보기 API에 QueryString이 추가되어 API 코드를 리팩토링합니다.

## 작업사항
- 자습실 목록 보기/신청/취소 API에 QueryString 추가
- 자습실 신청 페이지 로직 변경
- 자습실 '신청함' 태그 기능 추가

## 변경로직
자습실 페이지 진입 >> 자습실 이용 시간 선택 >> 자습실 목록 조회

### 변경전
자습실 페이지 진입 >> 자습실 목록 조회 >> 자습실 이용 시간 선택 or 자습실 신청/취소

### 변경후
자습실 페이지 진입 >> 자습실 이용 시간 선택 >> 자습실 목록 조회 >> 자습실 신청/취소

## UI
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-24 at 23 25 28](https://user-images.githubusercontent.com/101160430/227552133-a0b4c37a-638f-4de4-bc26-be11dd2e2556.png)
![Simulator Screen Shot - iPhone 14 Pro - 2023-03-24 at 23 25 24](https://user-images.githubusercontent.com/101160430/227552227-a56ccdf8-d4fc-493d-8e0b-6e95f2cdabc9.png)

