### PR TITLE
fix :: 자습실 자리 취소 시 전체 자습실 취소 오류 해결

### DIFF
--- a/Projects/Features/StudyRoomFeature/Sources/StudyRoomDetail/StudyRoomDetailView.swift
+++ b/Projects/Features/StudyRoomFeature/Sources/StudyRoomDetail/StudyRoomDetailView.swift
@@ -57,7 +57,7 @@ struct StudyRoomDetailView: View {
                 DMSWideButton(text: "취소", style: .contained, color: .GrayScale.gray6) {
                     viewModel.cancelStudyRoomSeat()
                 }
-//                .disabled(viewModel.selectedSeat == nil)
+                .disabled(viewModel.selectedSeat == nil)
 
                 DMSWideButton(text: "신청", style: .contained, color: .System.primary) {
                     viewModel.applyStudyRoomSeat()

--- a/Projects/Features/StudyRoomFeature/Sources/StudyRoomDetail/StudyRoomDetailViewModel.swift
+++ b/Projects/Features/StudyRoomFeature/Sources/StudyRoomDetail/StudyRoomDetailViewModel.swift
@@ -112,8 +112,9 @@ final class StudyRoomDetailViewModel: BaseViewModel {
     }
 
     func cancelStudyRoomSeat() {
+        guard let selectedSeat else { return }
         addCancellable(
-            cancelStudyRoomSeatUseCase.execute(timeSlot: timeSlotParam)
+            cancelStudyRoomSeatUseCase.execute(seatID: selectedSeat.id, timeSlot: timeSlotParam)
         ) { [weak self] _ in
             self?.fetchDetailStudyRoom()
             self?.isShowingToast = true

--- a/Projects/Services/APIKit/Sources/StudyRoomsAPI.swift
+++ b/Projects/Services/APIKit/Sources/StudyRoomsAPI.swift
@@ -10,7 +10,7 @@ public enum StudyRoomsAPI {
     case fetchDetailStudyRoom(roomID: String, timeSlot: String)
     case fetchMyStudyRoomApplicationItems
     case applyStudyRoomSeat(seatID: String, timeSlot: String)
-    case cancelStudyRoomSeat(timeSlot: String)
+    case cancelStudyRoomSeat(seatID: String, timeSlot: String)
     case fetchStudyroomTimeList
 }
 
@@ -36,8 +36,8 @@ extension StudyRoomsAPI: DmsAPI {
         case let .applyStudyRoomSeat(id, _):
             return "/seats/\(id)"
 
-        case .cancelStudyRoomSeat:
-            return "/seats"
+        case let .cancelStudyRoomSeat(id, _):
+            return "/seats/\(id)"
 
         case .fetchMyStudyRoomApplicationItems:
             return "/my"
@@ -96,7 +96,7 @@ extension StudyRoomsAPI: DmsAPI {
                 encoding: URLEncoding.queryString
             )
 
-        case let .cancelStudyRoomSeat(timeSlot):
+        case let .cancelStudyRoomSeat(_, timeSlot):
             return .requestParameters(
                 parameters: [
                     "time_slot": timeSlot

--- a/Projects/Services/DataModule/Sources/StudyRooms/Repositories/Impl/StudyRoomsRepositoryImpl.swift
+++ b/Projects/Services/DataModule/Sources/StudyRooms/Repositories/Impl/StudyRoomsRepositoryImpl.swift
@@ -34,8 +34,8 @@ public struct StudyRoomsRepositoryImpl: StudyRoomsRepository {
         remoteStudyRoomsDataSource.applyStudyRoomSeat(seatID: seatID, timeSlot: timeSlot)
     }
 
-    public func cancelStudyRoomSeat(timeSlot: String) -> AnyPublisher<Void, DmsError> {
-        remoteStudyRoomsDataSource.cancelStudyRoomSeat(timeSlot: timeSlot)
+    public func cancelStudyRoomSeat(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError> {
+        remoteStudyRoomsDataSource.cancelStudyRoomSeat(seatID: seatID, timeSlot: timeSlot)
     }
 
     public func fetchMyStudyRoomApplicationItems() -> AnyPublisher<MyStudyRoomAppItemsEntity, DmsError> {

--- a/Projects/Services/DataModule/Sources/StudyRooms/UseCases/Impl/CancelStudyRoomSeatUseCaseImpl.swift
+++ b/Projects/Services/DataModule/Sources/StudyRooms/UseCases/Impl/CancelStudyRoomSeatUseCaseImpl.swift
@@ -10,7 +10,7 @@ public struct CancelStudyRoomSeatUseCaseImpl: CancelStudyRoomSeatUseCase {
         self.studyRoomsRepository = studyRoomsRepository
     }
 
-    public func execute(timeSlot: String) -> AnyPublisher<Void, DmsError> {
-        studyRoomsRepository.cancelStudyRoomSeat(timeSlot: timeSlot)
+    public func execute(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError> {
+        studyRoomsRepository.cancelStudyRoomSeat(seatID: seatID, timeSlot: timeSlot)
     }
 }

--- a/Projects/Services/DomainModule/Sources/StudyRooms/Repository/StudyRoomsRepository.swift
+++ b/Projects/Services/DomainModule/Sources/StudyRooms/Repository/StudyRoomsRepository.swift
@@ -8,7 +8,7 @@ public protocol StudyRoomsRepository {
     func fetchStudyRoomList(timeSlot: String?) -> AnyPublisher<[StudyRoomEntity], DmsError>
     func fetchDetailStudyRoom(roomID: String, timeSlot: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError>
     func applyStudyRoomSeat(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError>
-    func cancelStudyRoomSeat(timeSlot: String) -> AnyPublisher<Void, DmsError>
+    func cancelStudyRoomSeat(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError>
     func fetchMyStudyRoomApplicationItems() -> AnyPublisher<MyStudyRoomAppItemsEntity, DmsError>
     func fetchStudyroomTimeList() -> AnyPublisher<StudyroomTimeListEntity, DmsError>
 }

--- a/Projects/Services/DomainModule/Sources/StudyRooms/UseCases/CancelStudyRoomSeatUseCase.swift
+++ b/Projects/Services/DomainModule/Sources/StudyRooms/UseCases/CancelStudyRoomSeatUseCase.swift
@@ -3,5 +3,5 @@ import DataMappingModule
 import ErrorModule
 
 public protocol CancelStudyRoomSeatUseCase {
-    func execute(timeSlot: String) -> AnyPublisher<Void, DmsError>
+    func execute(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError>
 }

--- a/Projects/Services/NetworkModule/Sources/StudyRooms/Remote/Impl/RemoteStudyRoomsDataSourceImpl.swift
+++ b/Projects/Services/NetworkModule/Sources/StudyRooms/Remote/Impl/RemoteStudyRoomsDataSourceImpl.swift
@@ -48,7 +48,7 @@ public final class RemoteStudyRoomsDataSourceImpl: BaseRemoteDataSource<StudyRoo
         request(.applyStudyRoomSeat(seatID: seatID, timeSlot: timeSlot))
     }
 
-    public func cancelStudyRoomSeat(timeSlot: String) -> AnyPublisher<Void, DmsError> {
-        request(.cancelStudyRoomSeat(timeSlot: timeSlot))
+    public func cancelStudyRoomSeat(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError> {
+        request(.cancelStudyRoomSeat(seatID: seatID, timeSlot: timeSlot))
     }
 }

--- a/Projects/Services/NetworkModule/Sources/StudyRooms/Remote/RemoteStudyRoomsDataSource.swift
+++ b/Projects/Services/NetworkModule/Sources/StudyRooms/Remote/RemoteStudyRoomsDataSource.swift
@@ -11,7 +11,7 @@ public protocol RemoteStudyRoomsDataSource {
     func fetchStudyRoomList(timeSlot: String?) -> AnyPublisher<[StudyRoomEntity], DmsError>
     func fetchDetailStudyRoom(roomID: String, timeSlot: String) -> AnyPublisher<DetailStudyRoomEntity, DmsError>
     func applyStudyRoomSeat(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError>
-    func cancelStudyRoomSeat(timeSlot: String) -> AnyPublisher<Void, DmsError>
+    func cancelStudyRoomSeat(seatID: String, timeSlot: String) -> AnyPublisher<Void, DmsError>
     func fetchMyRemainApplicationItems() -> AnyPublisher<MyStudyRoomAppItemsEntity, DmsError>
     func fetchStudyroomTimeList() -> AnyPublisher<StudyroomTimeListEntity, DmsError>
 }


### PR DESCRIPTION
## 개요
- 자습실 자리 취소 시 seat-id를 같이 전송하여 전체 자습실의 신청이 취소되는 오류를 해결합니다.

## 작업사항
- 자습실 신청 취소 path에 seat id 추가

## 변경로직
자습실 신청 취소(timeSlot: timeSlot) --> 자습실 신청 취소(seatID: seatID, timeSlot: timeSlot)

### 변경전
자습실 신청 취소(timeSlot: timeSlot)

### 변경후
자습실 신청 취소(seatID: seatID, timeSlot: timeSlot)
